### PR TITLE
add pj_websock_get_parent() to get websocket server object

### DIFF
--- a/websock/websock.c
+++ b/websock/websock.c
@@ -832,6 +832,11 @@ PJ_DEF(pj_status_t) pj_websock_set_support_subproto(pj_websock_t *srv,
     return PJ_SUCCESS;
 }
 
+PJ_DECL(pj_websock_t *) pj_websock_get_parent(pj_websock_t *c)
+{
+    return c->parent;
+}
+
 static pj_bool_t on_connect_complete(pj_websock_transport_t *t,
                                      pj_status_t status)
 {

--- a/websock/websock.h
+++ b/websock/websock.h
@@ -416,6 +416,17 @@ PJ_DECL(const char *) pj_websock_state_str(int state);
  */
 PJ_DECL(const char *) pj_websock_transport_str(int type);
 
+/**
+ * Get websocket parent
+ * A new connection(client) object get the websocket server object (created by
+ * \a pj_websock_listen)
+ *
+ * @param c    The websocket connection object
+ * @return   the server object
+ *
+ */
+PJ_DECL(pj_websock_t *) pj_websock_get_parent(pj_websock_t *c);
+
 PJ_END_DECL
 /**
  * @}


### PR DESCRIPTION
In websocket server, a new connection(client) object may want to get the websocket server object